### PR TITLE
[KVM_ON_S390] support guest installation on s390x lpar via virt-install

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -728,13 +728,18 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/reboot_and_wait_up_normal";
     }
     else {
-        load_boot_tests();
-        if (get_var("AUTOYAST")) {
-            loadtest "autoyast/installation";
-            loadtest "virt_autotest/reboot_and_wait_up_normal";
+        if (!check_var('ARCH', 's390x')) {
+            load_boot_tests();
+            if (get_var("AUTOYAST")) {
+                loadtest "autoyast/installation";
+                loadtest "virt_autotest/reboot_and_wait_up_normal";
+            }
+            else {
+                load_inst_tests();
+                loadtest "virt_autotest/login_console";
+            }
         }
-        else {
-            load_inst_tests();
+        elsif (check_var('ARCH', 's390x')) {
             loadtest "virt_autotest/login_console";
         }
         loadtest "virt_autotest/install_package";

--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -17,13 +17,18 @@ use testapi;
 use virt_utils;
 
 sub get_script_run {
-    my $prd_version = script_output("cat /etc/issue");
-    my $pre_test_cmd;
-    if ($prd_version =~ m/SUSE Linux Enterprise Server 11/) {
-        $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-standalone-run";
+    my $pre_test_cmd = "";
+    if (check_var('ARCH', 's390x')) {
+        $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-virt_install_withopt-run";
     }
     else {
-        $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-virt_install_withopt-run";
+        my $prd_version = script_output("cat /etc/issue");
+        if ($prd_version =~ m/SUSE Linux Enterprise Server 11/) {
+            $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-standalone-run";
+        }
+        else {
+            $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-virt_install_withopt-run";
+        }
     }
     # testsuite setting pre-handling for no service pack products
     handle_sp_in_settings_with_fcs("GUEST_PATTERN");

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -23,6 +23,13 @@ sub login_to_console {
     my ($self, $timeout) = @_;
     $timeout //= 240;
 
+    if (check_var('ARCH', 's390x')) {
+        #Switch to s390x lpar console
+        reset_consoles;
+        my $svirt = select_console('svirt', await_console => 0);
+        return;
+    }
+
     reset_consoles;
     select_console 'sol', await_console => 0;
 

--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -17,10 +17,23 @@ use testapi;
 use login_console;
 use ipmi_backend_utils;
 use base "proxymode";
+use power_action_utils 'power_action';
 
 sub reboot_and_wait_up {
     my $self           = shift;
     my $reboot_timeout = shift;
+
+    if (check_var('ARCH', 's390x')) {
+        record_info('INFO', 'Reboot LPAR');
+        #Reboot s390x lpar
+        power_action('reboot', observe => 1, keepconsole => 1);
+        #Wait for s390x lpar bootup
+        sleep 120;
+        #Switch to s390x lpar console
+        reset_consoles;
+        my $svirt = select_console('svirt', await_console => 0);
+        return;
+    }
 
     if (get_var("PROXY_MODE")) {
         select_console('root-console');

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -152,7 +152,12 @@ sub run_test {
         $timeout = 300;
     }
 
-    my $test_cmd      = $self->get_script_run();
+    my $test_cmd = $self->get_script_run();
+    #FOR S390X LPAR
+    if (check_var('ARCH', 's390x')) {
+        virt_utils::lpar_cmd("$test_cmd");
+        return;
+    }
     my $script_output = $self->execute_script_run($test_cmd, $timeout);
 
     if ($add_junit_log_flag eq "yes") {


### PR DESCRIPTION
Try to use svirt BACKEDN to trigger automation Guests Installation test run on s390x LPAR

found that in svirt console we don't have a serial line and can't rely on assert_script_run check, so try to create new lpar_cmd and lpar_cmd_with_retry funs to trigger cmd, also use upload_asset to upload log to compare cmd output.

- Needles: no need
- Verification run: 
S390 GUEST INSTALLATION  SLES15SP1
http://10.67.17.251/tests/21
X86 GUEST INSTALLATION  SLES15SP1 
http://10.67.17.251/tests/17
X86 HOST UPGRADE SLES15->SLES15SP1
http://10.67.17.251/tests/32
