### PR TITLE
[KVM_ON_S390] support guest installation on s390x lpar via virt-install

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -712,15 +712,20 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/reboot_and_wait_up_normal";
     }
     else {
-        load_boot_tests();
-        if (get_var("AUTOYAST")) {
-            loadtest "autoyast/installation";
-            loadtest "virt_autotest/reboot_and_wait_up_normal";
+        if (!check_var('ARCH', 's390x')) {
+            load_boot_tests();
+            if (get_var("AUTOYAST")) {
+                loadtest "autoyast/installation";
+                loadtest "virt_autotest/reboot_and_wait_up_normal";
+            }
+            else {
+                load_inst_tests();
+                loadtest "virt_autotest/login_console";
+            }
         }
-        else {
-            load_inst_tests();
+        elsif (check_var('ARCH', 's390x')) {
             loadtest "virt_autotest/login_console";
-        }
+	}
         loadtest "virt_autotest/install_package";
         loadtest "virt_autotest/update_package";
         loadtest "virt_autotest/reboot_and_wait_up_normal";

--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -17,13 +17,18 @@ use testapi;
 use virt_utils;
 
 sub get_script_run {
-    my $prd_version = script_output("cat /etc/issue");
-    my $pre_test_cmd;
-    if ($prd_version =~ m/SUSE Linux Enterprise Server 11/) {
-        $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-standalone-run";
+    my $pre_test_cmd = "";
+    if (check_var('ARCH', 's390x')) {
+        $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-virt_install_withopt-run";
     }
     else {
-        $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-virt_install_withopt-run";
+        my $prd_version = script_output("cat /etc/issue");
+        if ($prd_version =~ m/SUSE Linux Enterprise Server 11/) {
+            $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-standalone-run";
+        }
+        else {
+            $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-virt_install_withopt-run";
+        }
     }
     # testsuite setting pre-handling for no service pack products
     handle_sp_in_settings_with_fcs("GUEST_PATTERN");

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -14,6 +14,7 @@ use strict;
 use warnings;
 use base "virt_autotest_base";
 use testapi;
+use virt_utils;
 
 sub install_package {
     my $qa_server_repo = get_var('QA_HEAD_REPO', '');
@@ -23,8 +24,15 @@ sub install_package {
         set_var('QA_HEAD_REPO', $qa_server_repo);
         bmwqemu::save_vars();
     }
-    script_run "zypper --non-interactive rr server-repo";
-    assert_script_run("zypper --non-interactive --no-gpg-check ar -f '$qa_server_repo' server-repo");
+    if (check_var('ARCH', 's390x')) {
+        lpar_cmd("zypper --non-interactive rr server-repo");
+        record_info('INFO', 'Setup QA_HEAD_REPO');
+        lpar_cmd("zypper --non-interactive --no-gpg-check ar -f '$qa_server_repo' server-repo");
+    }
+    else {
+        script_run "zypper --non-interactive rr server-repo";
+        assert_script_run("zypper --non-interactive --no-gpg-check ar -f '$qa_server_repo' server-repo");
+    }
 
     #workaround for dependency on xmlstarlet for qa_lib_virtauto on sles11sp4 and sles12sp1
     #workaround for dependency on bridge-utils for qa_lib_virtauto on sles15sp0
@@ -44,14 +52,30 @@ sub install_package {
         $dependency_rpms = 'bridge-utils';
     }
     if ($dependency_repo) {
-        assert_script_run("zypper --non-interactive --no-gpg-check ar -f ${dependency_repo} dependency_repo");
-        assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref", 180);
-        assert_script_run("zypper --non-interactive in $dependency_rpms");
-        assert_script_run("zypper --non-interactive rr dependency_repo");
+        if (check_var('ARCH', 's390x')) {
+            lpar_cmd("zypper --non-interactive --no-gpg-check ar -f ${dependency_repo} dependency_repo");
+            lpar_cmd("zypper --non-interactive --gpg-auto-import-keys ref");
+            lpar_cmd("zypper --non-interactive in $dependency_rpms");
+            lpar_cmd("zypper --non-interactive rr dependency_repo");
+        }
+        else {
+            assert_script_run("zypper --non-interactive --no-gpg-check ar -f ${dependency_repo} dependency_repo");
+            assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref", 180);
+            assert_script_run("zypper --non-interactive in $dependency_rpms");
+            assert_script_run("zypper --non-interactive rr dependency_repo");
+        }
     }
+
     #install qa_lib_virtauto
-    assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref", 180);
-    assert_script_run("zypper --non-interactive in qa_lib_virtauto",         1800);
+    if (check_var('ARCH', 's390x')) {
+        lpar_cmd("zypper --non-interactive --gpg-auto-import-keys ref");
+        record_info('INFO', 'Installa Package qa_lib_virtauto');
+        lpar_cmd("zypper --non-interactive in qa_lib_virtauto");
+    }
+    else {
+        assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref", 180);
+        assert_script_run("zypper --non-interactive in qa_lib_virtauto",         1800);
+    }
 
     if (get_var("PROXY_MODE")) {
         if (get_var("XEN")) {

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -23,6 +23,13 @@ sub login_to_console {
     my ($self, $timeout) = @_;
     $timeout //= 240;
 
+    if (check_var('ARCH', 's390x')) {
+        #Switch to s390x lpar console
+        reset_consoles;
+        my $svirt = select_console('svirt', await_console => 0);
+        return;
+    }
+
     reset_consoles;
     select_console 'sol', await_console => 0;
 

--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -22,6 +22,19 @@ sub reboot_and_wait_up {
     my $self           = shift;
     my $reboot_timeout = shift;
 
+    if (check_var('ARCH', 's390x')) {
+        record_info('INFO', 'Do Reboot LPAR');
+        #type reboot
+        my $cmd = "reboot -f\n";
+        type_string "$cmd";
+        #Wait for s390x lpar bootup
+        sleep 120;
+        #Switch to s390x lpar console
+        reset_consoles;
+        my $svirt = select_console('svirt', await_console => 0);
+        return;
+    }
+
     if (get_var("PROXY_MODE")) {
         select_console('root-console');
         my $test_machine = get_var("TEST_MACHINE");

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -31,20 +31,29 @@ sub update_package {
     }
 
     $update_pkg_cmd = $update_pkg_cmd . " 2>&1 | tee /tmp/update_virt_rpms.log ";
-    $ret            = $self->execute_script_run($update_pkg_cmd, 7200);
-    upload_logs("/tmp/update_virt_rpms.log");
-    save_screenshot;
-    if ($ret !~ /Need to reboot system to make the rpms work/m) {
-        die " Update virt rpms fail, going to terminate following test!";
+    if (check_var('ARCH', 's390x')) {
+        record_info('INFO', 'Do Host Upgrade');
+        lpar_cmd("$update_pkg_cmd");
+        upload_asset"/tmp/update_virt_rpms.log", 1, 1;
     }
+    else {
+        $ret            = $self->execute_script_run($update_pkg_cmd, 7200);
+        upload_logs("/tmp/update_virt_rpms.log");
+        save_screenshot;
+        if ($ret !~ /Need to reboot system to make the rpms work/m) {
+            die " Update virt rpms fail, going to terminate following test!";
+        }
+   }
 
 }
 
 sub run {
     my $self = shift;
     $self->update_package();
-    set_serial_console_on_vh('', '', 'xen') if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"));
-    set_serial_console_on_vh('', '', 'kvm') if (check_var("HOST_HYPERVISOR", "kvm") || check_var("SYSTEM_ROLE", "kvm"));
+    if (!check_var('ARCH', 's390x')){
+        set_serial_console_on_vh('', '', 'xen') if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"));
+        set_serial_console_on_vh('', '', 'kvm') if (check_var("HOST_HYPERVISOR", "kvm") || check_var("SYSTEM_ROLE", "kvm"));
+    }
     update_guest_configurations_with_daily_build();
 }
 

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -19,6 +19,7 @@ use testapi;
 use Data::Dumper;
 use XML::Writer;
 use IO::File;
+use virt_utils;
 
 sub analyzeResult {
     die "You need to overload analyzeResult in your class";
@@ -153,6 +154,12 @@ sub run_test {
     }
 
     my $test_cmd      = $self->get_script_run();
+    #FOR S390X LPAR
+    if (check_var('ARCH', 's390x')) {
+        record_info('INFO', 'Do Guest Installation');
+        lpar_cmd("$test_cmd");
+        return;
+    }
     my $script_output = $self->execute_script_run($test_cmd, $timeout);
 
     if ($add_junit_log_flag eq "yes") {

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -26,7 +26,7 @@ use virt_autotest_base;
 use version_utils 'is_sle';
 
 our @EXPORT
-  = qw(update_guest_configurations_with_daily_build repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks);
+  = qw(update_guest_configurations_with_daily_build repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd);
 
 sub get_version_for_daily_build_guest {
     my $version = '';
@@ -48,14 +48,26 @@ sub repl_repo_in_sourcefile {
     my $verorig = "source.http.sles-" . get_version_for_daily_build_guest . "-64";
     my $veritem = check_var('ARCH', 'x86_64') ? $verorig : get_required_var('ARCH') . ".$verorig";
     if (get_var("REPO_0")) {
-        my $location = &virt_autotest_base::execute_script_run("", "perl /usr/share/qa/tools/location_detect_impl.pl", 60);
-        $location =~ s/[\r\n]+$//;
+	my $location = "";
+	if (check_var('ARCH', 's390x')) {
+            my $location = type_string("perl /usr/share/qa/tools/location_detect_impl.pl\n");
+        }
+	else{
+            my $location = &virt_autotest_base::execute_script_run("", "perl /usr/share/qa/tools/location_detect_impl.pl", 60);
+            $location =~ s/[\r\n]+$//;
+	}
         my $soucefile = "/usr/share/qa/virtautolib/data/" . "sources." . "$location";
         my $newrepo   = "http://openqa.suse.de/assets/repo/" . get_var("REPO_0");
         my $shell_cmd
           = "if grep $veritem $soucefile >> /dev/null;then sed -i \"s#^$veritem=.*#$veritem=$newrepo#\" $soucefile;else echo \"$veritem=$newrepo\" >> $soucefile;fi";
-        assert_script_run($shell_cmd);
-        assert_script_run("grep \"$veritem\" $soucefile");
+        if (check_var('ARCH', 's390x')) {
+            lpar_cmd("$shell_cmd");
+            lpar_cmd("grep \"$veritem\" $soucefile");
+        }
+        else{
+            assert_script_run($shell_cmd);
+            assert_script_run("grep \"$veritem\" $soucefile");
+        }
     }
     else {
         print "Do not need to change resource for $veritem item\n";
@@ -78,11 +90,18 @@ sub repl_module_in_sourcefile {
     my $source_file = "/usr/share/qa/virtautolib/data/sources.*";
     my $command     = "sed -ri 's#^(${replaced_item}).*\$#\\1$daily_build_module#g' $source_file";
     print "Debug: the command to execute is:\n$command \n";
-    assert_script_run($command);
-    save_screenshot;
-    assert_script_run("grep Module $source_file -r");
-    save_screenshot;
-    upload_logs "/usr/share/qa/virtautolib/data/sources.de";
+    if (check_var('ARCH', 's390x')) {
+        lpar_cmd("$command");
+        lpar_cmd("grep Module $source_file -r");
+        upload_asset"/usr/share/qa/virtautolib/data/sources.de", 1, 1;
+    }
+    else{
+        assert_script_run($command);
+        save_screenshot;
+        assert_script_run("grep Module $source_file -r");
+        save_screenshot;
+        upload_logs "/usr/share/qa/virtautolib/data/sources.de";
+    }
 }
 
 sub repl_addon_with_daily_build_module_in_files {
@@ -196,6 +215,22 @@ sub clean_up_red_disks {
     }
     my $disks_fs_overview = script_output($get_disks_fs_overview, $wait_script, type_command => 1, proceed_on_failure => 1);
     diag("Debug info: Disks and File Systems Overview:\n $disks_fs_overview");
+}
+
+sub lpar_cmd {
+    my ($cmd, $mesg, $args) = @_;
+    die 'Command not provided' unless $cmd;
+    my $mesg = shift;
+
+    $args->{ignore_return_code} ||= 0;
+    my $ret = console('svirt')->run_cmd($cmd);
+    if ($ret == 0){
+        diag "Command $mesg on S390X LPAR returned: SUCESS";
+    }
+    unless ($args->{ignore_return_code} || !$ret) {
+        diag "Command $mesg on S390X LPAR returned: FAIL";
+        die 'Find new failure, please check manually';
+    }
 }
 
 1;


### PR DESCRIPTION
Try to use svirt BACKEDN to trigger automation Guests Installation test run on s390x LPAR

found that in svirt console we don't have a serial line and can't rely on assert_script_run check, so try to create new lpar_cmd and lpar_cmd_with_retry funs to trigger cmd, also use upload_asset to upload log to compare cmd output.

    Needles: no need
    Verification run:
    S390 GUEST INSTALLATION SLES15SP1
    http://10.67.17.251/tests/39
    X86 GUEST INSTALLATION SLES15SP1
    http://10.67.17.251/tests/17
    X86 HOST UPGRADE SLES15->SLES15SP1
    http://10.67.17.251/tests/32